### PR TITLE
README updates

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -50,8 +50,8 @@ yarn global add open-pip-cli
 npm install --global open-pip-cli
 ```
 
-### Requirements
-As the native picture-in-picture player is only available in macOS Sierra (10.12) and above, this module will also only with with those versions.
+## requirements
+As the native picture-in-picture player is only available in macOS Sierra (10.12) and above, this module will also only work with with those versions.
 
 ### Author
 

--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Known **working** formats
   - mp4
   - m4v
   - mov
+  - m3u8
 
 Known **not** working formats
   - mkv
@@ -18,6 +19,23 @@ Known **not** working formats
 ## example
 
 ![example](https://cloud.githubusercontent.com/assets/5027156/24427435/3529cfc4-140b-11e7-9799-de7326ddc088.gif)
+
+You can also pipe any video URL to `open-pip`. For example, using the [ytdl](https://www.npmjs.com/package/ytdl) module, you can play a YouTube video:
+
+```sh
+yarn global add ytdl
+ytdl --print-url --filter-container=mp4 _HSylqgVYQI | open-pip
+```
+
+Using the [twitch-url-cli](https://www.npmjs.com/package/twitch-url-cli) module, you can stream a Twitch channel (you need a Twitch client ID though)
+
+```sh
+yarn global add twitch-url-cli
+echo "abcdefghijklmno12345" > ~/.twitch-client-id
+twitch-url BobRoss | open-pip
+```
+
+Let us know if you have examples for more services.
 
 ## install
 
@@ -31,6 +49,9 @@ yarn global add open-pip-cli
 ```sh
 npm install --global open-pip-cli
 ```
+
+### Requirements
+As the native picture-in-picture player is only available in macOS Sierra (10.12) and above, this module will also only with with those versions.
 
 ### Author
 


### PR DESCRIPTION
– Add .m3u8 to list of supported formats
– Add examples for YouTube and Twitch
– mention requirement for macOS Sierra (at least in 10.11 Safari didn't have the feature, so I suppose the standalone version also wasn't there)